### PR TITLE
Callback-less actions.

### DIFF
--- a/src/actions/auth.test.js
+++ b/src/actions/auth.test.js
@@ -93,20 +93,18 @@ describe('auth action creators', () => {
       password: 'Aa123456',
     });
     store.set = jest.fn();
-    const cb = jest.fn();
     const resp = {
       token: 'this.is.token',
       user: user,
     };
     fetchMock.post(`${API_URL}/authenticate`, resp);
 
-    return auth.authenticate(values, mockDispatch, cb).then(() => {
+    return auth.authenticate(values, mockDispatch).then(() => {
       expect(store.set.mock.calls[0])
         .toEqual(['token', `Bearer ${resp.token}`]);
       expect(store.set).toHaveBeenLastCalledWith('user', resp.user);
       expect(store.set).toHaveBeenCalledTimes(2);
       expect(mockDispatch).toHaveBeenCalledWith(expectedSignupLoginAction);
-      expect(cb).toHaveBeenCalled();
     });
   });
 
@@ -115,7 +113,6 @@ describe('auth action creators', () => {
       email: 'test@mail.com',
       password: 'Aa123456',
     });
-    const cb = jest.fn();
     const resp = { message: 'User created' };
     const respAuth = {
       token: 'this.is.token',
@@ -125,7 +122,7 @@ describe('auth action creators', () => {
     fetchMock.post(`${API_URL}/authenticate`, respAuth);
     const reduxStore = mockStore(fromJS({ user: {} }));
 
-    return reduxStore.dispatch(auth.signupFetch(values, cb)).then(() => {
+    return reduxStore.dispatch(auth.signupFetch(values)).then(() => {
       expect(fetchMock.lastCall()[0]).toEqual(`${API_URL}/authenticate`);
     });
   });
@@ -157,7 +154,6 @@ describe('auth action creators', () => {
       email: 'test@mail.com',
       password: 'Aa123456',
     });
-    const cb = jest.fn();
     const resp = {
       error: {
         message: 'Wrong password',
@@ -177,13 +173,12 @@ describe('auth action creators', () => {
 
   it('should make call to logout action', () => {
     store.clear = jest.fn();
-    const cb = jest.fn();
     const reduxStore = mockStore(fromJS({ user: {} }));
-    reduxStore.dispatch(auth.logoutAction(cb));
 
-    expect(store.clear).toHaveBeenCalled();
-    expect(reduxStore.getActions()[0]).toEqual(expectedLogoutAction);
-    expect(cb).toHaveBeenCalled();
+    return reduxStore.dispatch(auth.logoutAction()).then(() => {
+      expect(store.clear).toHaveBeenCalled();
+      expect(reduxStore.getActions()[0]).toEqual(expectedLogoutAction);
+    });
   });
 
   it('should fail to make call to forgotPassword fetch', () => {
@@ -213,15 +208,11 @@ describe('auth action creators', () => {
       newPassword: 'Bb123456',
     });
     const code = 'this.is.code';
-    const cb = jest.fn();
     const resp = { message: 'Password changed.' };
     fetchMock.post(`${API_URL}/recoverPassword/${code}`, resp);
     const reduxStore = mockStore(fromJS({ auth: {} }));
 
-    return reduxStore.dispatch(auth.recoverPasswordFetch(values, code, cb))
-      .then(() => {
-        expect(cb).toHaveBeenCalled();
-      });
+    return reduxStore.dispatch(auth.recoverPasswordFetch(values, code));
   });
 
   it('should fail to make call to recoverPassword fetch', () => {
@@ -254,13 +245,12 @@ describe('auth action creators', () => {
     });
     store.get = jest.fn(() => user);
     store.set = jest.fn();
-    const cb = jest.fn();
     const resp = { email: 'new@mail.com' };
     fetchMock.post(`${API_URL}/emailConfirm`, resp);
     const reduxStore = mockStore(fromJS({ auth: {} }));
 
 
-    return reduxStore.dispatch(auth.emailConfirmFetch(values, cb))
+    return reduxStore.dispatch(auth.emailConfirmFetch(values))
       .then(() => {
         expect(store.get).toHaveBeenCalledWith('user');
         expect(store.set).toHaveBeenCalledWith('user', {
@@ -275,7 +265,6 @@ describe('auth action creators', () => {
           updatedAt: '2016-10-06T14:55:40.722Z',
         });
         expect(reduxStore.getActions()[0]).toEqual(expectedEmailConfirmAction);
-        expect(cb).toHaveBeenCalled();
       });
   });
 

--- a/src/components/Button/__snapshots__/snapshot.test.js.snap
+++ b/src/components/Button/__snapshots__/snapshot.test.js.snap
@@ -7,7 +7,7 @@ exports[`Button component snapshot renders basic required data 1`] = `
 
 exports[`Button component snapshot renders empty button 1`] = `
 <button
-  className="empty_1b6lvt9">
+  className="empty_6ajk08">
   Login
 </button>
 `;

--- a/src/components/Pagination/__snapshots__/snapshot.test.js.snap
+++ b/src/components/Pagination/__snapshots__/snapshot.test.js.snap
@@ -11,7 +11,7 @@ exports[`Pagination component snapshot renders data with current page 1 1`] = `
     </li>
     <li>
       <button
-        className="empty_1b6lvt9"
+        className="empty_6ajk08"
         onClick={[Function]}
         type="button">
         2
@@ -19,7 +19,7 @@ exports[`Pagination component snapshot renders data with current page 1 1`] = `
     </li>
     <li>
       <button
-        className="empty_1b6lvt9"
+        className="empty_6ajk08"
         onClick={[Function]}
         type="button">
         3
@@ -27,7 +27,7 @@ exports[`Pagination component snapshot renders data with current page 1 1`] = `
     </li>
     <li>
       <button
-        className="empty_1b6lvt9"
+        className="empty_6ajk08"
         onClick={[Function]}
         type="button">
         4
@@ -35,7 +35,7 @@ exports[`Pagination component snapshot renders data with current page 1 1`] = `
     </li>
     <li>
       <button
-        className="empty_1b6lvt9"
+        className="empty_6ajk08"
         onClick={[Function]}
         type="button">
         5
@@ -43,7 +43,7 @@ exports[`Pagination component snapshot renders data with current page 1 1`] = `
     </li>
     <li>
       <button
-        className="empty_1b6lvt9"
+        className="empty_6ajk08"
         onClick={[Function]}
         type="button">
         <i
@@ -52,7 +52,7 @@ exports[`Pagination component snapshot renders data with current page 1 1`] = `
     </li>
     <li>
       <button
-        className="empty_1b6lvt9"
+        className="empty_6ajk08"
         onClick={[Function]}
         type="button">
         <i
@@ -71,7 +71,7 @@ exports[`Pagination component snapshot renders data with current page 5 1`] = `
   <ul>
     <li>
       <button
-        className="empty_1b6lvt9"
+        className="empty_6ajk08"
         onClick={[Function]}
         type="button">
         <i
@@ -80,7 +80,7 @@ exports[`Pagination component snapshot renders data with current page 5 1`] = `
     </li>
     <li>
       <button
-        className="empty_1b6lvt9"
+        className="empty_6ajk08"
         onClick={[Function]}
         type="button">
         <i
@@ -89,7 +89,7 @@ exports[`Pagination component snapshot renders data with current page 5 1`] = `
     </li>
     <li>
       <button
-        className="empty_1b6lvt9"
+        className="empty_6ajk08"
         onClick={[Function]}
         type="button">
         3
@@ -97,7 +97,7 @@ exports[`Pagination component snapshot renders data with current page 5 1`] = `
     </li>
     <li>
       <button
-        className="empty_1b6lvt9"
+        className="empty_6ajk08"
         onClick={[Function]}
         type="button">
         4
@@ -108,7 +108,7 @@ exports[`Pagination component snapshot renders data with current page 5 1`] = `
     </li>
     <li>
       <button
-        className="empty_1b6lvt9"
+        className="empty_6ajk08"
         onClick={[Function]}
         type="button">
         6
@@ -116,7 +116,7 @@ exports[`Pagination component snapshot renders data with current page 5 1`] = `
     </li>
     <li>
       <button
-        className="empty_1b6lvt9"
+        className="empty_6ajk08"
         onClick={[Function]}
         type="button">
         7
@@ -124,7 +124,7 @@ exports[`Pagination component snapshot renders data with current page 5 1`] = `
     </li>
     <li>
       <button
-        className="empty_1b6lvt9"
+        className="empty_6ajk08"
         onClick={[Function]}
         type="button">
         <i
@@ -133,7 +133,7 @@ exports[`Pagination component snapshot renders data with current page 5 1`] = `
     </li>
     <li>
       <button
-        className="empty_1b6lvt9"
+        className="empty_6ajk08"
         onClick={[Function]}
         type="button">
         <i
@@ -152,7 +152,7 @@ exports[`Pagination component snapshot renders data with current page being last
   <ul>
     <li>
       <button
-        className="empty_1b6lvt9"
+        className="empty_6ajk08"
         onClick={[Function]}
         type="button">
         <i
@@ -161,7 +161,7 @@ exports[`Pagination component snapshot renders data with current page being last
     </li>
     <li>
       <button
-        className="empty_1b6lvt9"
+        className="empty_6ajk08"
         onClick={[Function]}
         type="button">
         <i
@@ -170,7 +170,7 @@ exports[`Pagination component snapshot renders data with current page being last
     </li>
     <li>
       <button
-        className="empty_1b6lvt9"
+        className="empty_6ajk08"
         onClick={[Function]}
         type="button">
         4
@@ -178,7 +178,7 @@ exports[`Pagination component snapshot renders data with current page being last
     </li>
     <li>
       <button
-        className="empty_1b6lvt9"
+        className="empty_6ajk08"
         onClick={[Function]}
         type="button">
         5
@@ -186,7 +186,7 @@ exports[`Pagination component snapshot renders data with current page being last
     </li>
     <li>
       <button
-        className="empty_1b6lvt9"
+        className="empty_6ajk08"
         onClick={[Function]}
         type="button">
         6
@@ -194,7 +194,7 @@ exports[`Pagination component snapshot renders data with current page being last
     </li>
     <li>
       <button
-        className="empty_1b6lvt9"
+        className="empty_6ajk08"
         onClick={[Function]}
         type="button">
         7
@@ -215,7 +215,7 @@ exports[`Pagination component snapshot renders data with less than 5 pages 1`] =
   <ul>
     <li>
       <button
-        className="empty_1b6lvt9"
+        className="empty_6ajk08"
         onClick={[Function]}
         type="button">
         <i
@@ -224,7 +224,7 @@ exports[`Pagination component snapshot renders data with less than 5 pages 1`] =
     </li>
     <li>
       <button
-        className="empty_1b6lvt9"
+        className="empty_6ajk08"
         onClick={[Function]}
         type="button">
         1
@@ -235,7 +235,7 @@ exports[`Pagination component snapshot renders data with less than 5 pages 1`] =
     </li>
     <li>
       <button
-        className="empty_1b6lvt9"
+        className="empty_6ajk08"
         onClick={[Function]}
         type="button">
         3
@@ -243,7 +243,7 @@ exports[`Pagination component snapshot renders data with less than 5 pages 1`] =
     </li>
     <li>
       <button
-        className="empty_1b6lvt9"
+        className="empty_6ajk08"
         onClick={[Function]}
         type="button">
         <i

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -19,7 +19,7 @@ export class AppComponent extends Component {
     const { dispatch, router } = this.props;
 
     e.preventDefault();
-    dispatch(logoutAction(() => router.push('/login')));
+    dispatch(logoutAction()).then(() => router.push('/login'));
   }
 
   render() {

--- a/src/containers/App/test.js
+++ b/src/containers/App/test.js
@@ -6,7 +6,7 @@ import * as Actions from '../../actions/auth';
 
 describe('App component', () => {
   const children = <div>Test</div>;
-  const mockDispatch = jest.fn();
+  const mockDispatch = jest.fn(f => f);
   const mockRouter = {
     push: jest.fn(),
   };
@@ -17,7 +17,7 @@ describe('App component', () => {
     >{children}</AppComponent>
   );
   const instance = wrapper.instance();
-  Actions.logoutAction = jest.fn(cb => cb());
+  Actions.logoutAction = jest.fn(() => createResolvedThenable());
 
   it('handleLogout method', () => {
     const mockPreventDefault = jest.fn();
@@ -27,7 +27,7 @@ describe('App component', () => {
     instance.handleLogout(event);
 
     expect(mockPreventDefault).toHaveBeenCalledTimes(1);
-    expect(Actions.logoutAction).toHaveBeenCalledWith(jasmine.any(Function));
+    expect(Actions.logoutAction).toHaveBeenCalled();
     expect(mockRouter.push).toHaveBeenCalledWith('/login');
     expect(mockDispatch).toHaveBeenCalled();
   });

--- a/src/containers/App/test.js
+++ b/src/containers/App/test.js
@@ -17,7 +17,7 @@ describe('App component', () => {
     >{children}</AppComponent>
   );
   const instance = wrapper.instance();
-  Actions.logoutAction = jest.fn(() => createResolvedThenable());
+  Actions.logoutAction = jest.fn(() => Promise.resolve());
 
   it('handleLogout method', () => {
     const mockPreventDefault = jest.fn();
@@ -27,8 +27,12 @@ describe('App component', () => {
     instance.handleLogout(event);
 
     expect(mockPreventDefault).toHaveBeenCalledTimes(1);
-    expect(Actions.logoutAction).toHaveBeenCalled();
-    expect(mockRouter.push).toHaveBeenCalledWith('/login');
     expect(mockDispatch).toHaveBeenCalled();
+    expect(Actions.logoutAction).toHaveBeenCalled();
+    expect(mockRouter.push).not.toHaveBeenCalled();
+
+    return mockDispatch.mock.calls[0][0].then(() => {
+      expect(mockRouter.push).toHaveBeenCalledWith('/login');
+    });
   });
 });

--- a/src/containers/EmailConfirm/index.js
+++ b/src/containers/EmailConfirm/index.js
@@ -15,9 +15,9 @@ export class EmailConfirmComponent extends Component {
 
   componentDidMount() {
     const { dispatch, params, router } = this.props;
-    return dispatch(emailConfirmFetch({ token: params.code }, () =>
+    return dispatch(emailConfirmFetch({ token: params.code })).then(() =>
       setTimeout(() => router.push('/'), REDIRECTION),
-    ));
+    );
   }
 
   render() {

--- a/src/containers/EmailConfirm/snapshot.test.js
+++ b/src/containers/EmailConfirm/snapshot.test.js
@@ -4,10 +4,7 @@ import { fromJS } from 'immutable';
 import { EmailConfirmComponent } from './';
 
 describe('EmailConfirm component snapshot', () => {
-  const mockDispatch = () => createResolvedThenable();
-  // jest.mock('../../actions/auth', () => ({
-  //   emailConfirmFetch: () => createResolvedThenable(),
-  // }));
+  const mockDispatch = () => Promise.resolve();
 
   it('renders with pending request', () => {
     const tree = renderer.create(

--- a/src/containers/EmailConfirm/snapshot.test.js
+++ b/src/containers/EmailConfirm/snapshot.test.js
@@ -4,6 +4,11 @@ import { fromJS } from 'immutable';
 import { EmailConfirmComponent } from './';
 
 describe('EmailConfirm component snapshot', () => {
+  const mockDispatch = () => createResolvedThenable();
+  // jest.mock('../../actions/auth', () => ({
+  //   emailConfirmFetch: () => createResolvedThenable(),
+  // }));
+
   it('renders with pending request', () => {
     const tree = renderer.create(
       <EmailConfirmComponent
@@ -11,7 +16,7 @@ describe('EmailConfirm component snapshot', () => {
           emailConfirmationSuccess: false,
           emailConfirmationError: false,
         })}
-        dispatch={() => {}}
+        dispatch={mockDispatch}
         params={{}}
         router={{}}
       />
@@ -27,7 +32,7 @@ describe('EmailConfirm component snapshot', () => {
           emailConfirmationSuccess: true,
           emailConfirmationError: false,
         })}
-        dispatch={() => {}}
+        dispatch={mockDispatch}
         params={{}}
         router={{}}
       />
@@ -43,7 +48,7 @@ describe('EmailConfirm component snapshot', () => {
           emailConfirmationSuccess: false,
           emailConfirmationError: 'Token not found',
         })}
-        dispatch={() => {}}
+        dispatch={mockDispatch}
         params={{}}
         router={{}}
       />

--- a/src/containers/EmailConfirm/test.js
+++ b/src/containers/EmailConfirm/test.js
@@ -21,16 +21,19 @@ describe('EmailConfirm component', () => {
     />
   );
   const instance = wrapper.instance();
-  const emailConfirmThenable = createResolvedThenable();
-  Actions.emailConfirmFetch = jest.fn(() => emailConfirmThenable);
+  Actions.emailConfirmFetch = jest.fn(() => Promise.resolve());
 
   it('componentDidMount method', () => {
     instance.componentDidMount();
 
-    jest.runAllTimers();
-    expect(mockRouter.push).toHaveBeenCalledWith('/');
-    expect(Actions.emailConfirmFetch)
-      .toHaveBeenCalledWith({ token: 'this.is.code' });
     expect(mockDispatch).toHaveBeenCalled();
+    expect(Actions.emailConfirmFetch).toHaveBeenCalledWith({ token: 'this.is.code' });
+
+    expect(mockRouter.push).not.toHaveBeenCalled();
+
+    return mockDispatch.mock.calls[0][0].then(() => {
+      jest.runAllTimers();
+      expect(mockRouter.push).toHaveBeenCalledWith('/');
+    });
   });
 });

--- a/src/containers/EmailConfirm/test.js
+++ b/src/containers/EmailConfirm/test.js
@@ -28,7 +28,6 @@ describe('EmailConfirm component', () => {
 
     expect(mockDispatch).toHaveBeenCalled();
     expect(Actions.emailConfirmFetch).toHaveBeenCalledWith({ token: 'this.is.code' });
-
     expect(mockRouter.push).not.toHaveBeenCalled();
 
     return mockDispatch.mock.calls[0][0].then(() => {

--- a/src/containers/EmailConfirm/test.js
+++ b/src/containers/EmailConfirm/test.js
@@ -5,7 +5,7 @@ import { EmailConfirmComponent } from './';
 import * as Actions from '../../actions/auth';
 
 describe('EmailConfirm component', () => {
-  const mockDispatch = jest.fn();
+  const mockDispatch = jest.fn(f => f);
   const mockRouter = {
     push: jest.fn(),
   };
@@ -21,7 +21,8 @@ describe('EmailConfirm component', () => {
     />
   );
   const instance = wrapper.instance();
-  Actions.emailConfirmFetch = jest.fn((values, cb) => cb());
+  const emailConfirmThenable = createResolvedThenable();
+  Actions.emailConfirmFetch = jest.fn(() => emailConfirmThenable);
 
   it('componentDidMount method', () => {
     instance.componentDidMount();
@@ -29,7 +30,7 @@ describe('EmailConfirm component', () => {
     jest.runAllTimers();
     expect(mockRouter.push).toHaveBeenCalledWith('/');
     expect(Actions.emailConfirmFetch)
-      .toHaveBeenCalledWith({ token: 'this.is.code' }, jasmine.any(Function));
+      .toHaveBeenCalledWith({ token: 'this.is.code' });
     expect(mockDispatch).toHaveBeenCalled();
   });
 });

--- a/src/containers/Login/index.js
+++ b/src/containers/Login/index.js
@@ -34,7 +34,7 @@ export class LoginComponent extends Component {
 
   handleLogin(values) {
     const { dispatch, router } = this.props;
-    return dispatch(loginFetch(values, () => router.push('/')));
+    return dispatch(loginFetch(values)).then(() => router.push('/'));
   }
 
   render() {

--- a/src/containers/Login/test.js
+++ b/src/containers/Login/test.js
@@ -19,7 +19,7 @@ describe('Login component', () => {
     />
   );
   const instance = wrapper.instance();
-  Actions.loginFetch = jest.fn(() => createResolvedThenable());
+  Actions.loginFetch = jest.fn(() => Promise.resolve());
 
   it('validate function success', () => {
     const values = fromJS({
@@ -51,9 +51,12 @@ describe('Login component', () => {
     });
     instance.handleLogin(values);
 
-    expect(Actions.loginFetch)
-      .toHaveBeenCalledWith(values);
-    expect(mockRouter.push).toHaveBeenCalledWith('/');
     expect(mockDispatch).toHaveBeenCalled();
+    expect(Actions.loginFetch).toHaveBeenCalledWith(values);
+    expect(mockRouter.push).not.toHaveBeenCalled();
+
+    return mockDispatch.mock.calls[0][0].then(() => {
+        expect(mockRouter.push).toHaveBeenCalledWith('/');
+    });
   });
 });

--- a/src/containers/Login/test.js
+++ b/src/containers/Login/test.js
@@ -5,7 +5,7 @@ import { LoginComponent, validate } from './';
 import * as Actions from '../../actions/auth';
 
 describe('Login component', () => {
-  const mockDispatch = jest.fn();
+  const mockDispatch = jest.fn(f => f);
   const mockRouter = {
     push: jest.fn(),
   };
@@ -19,7 +19,7 @@ describe('Login component', () => {
     />
   );
   const instance = wrapper.instance();
-  Actions.loginFetch = jest.fn((values, cb) => cb());
+  Actions.loginFetch = jest.fn(() => createResolvedThenable());
 
   it('validate function success', () => {
     const values = fromJS({
@@ -52,7 +52,7 @@ describe('Login component', () => {
     instance.handleLogin(values);
 
     expect(Actions.loginFetch)
-      .toHaveBeenCalledWith(values, jasmine.any(Function));
+      .toHaveBeenCalledWith(values);
     expect(mockRouter.push).toHaveBeenCalledWith('/');
     expect(mockDispatch).toHaveBeenCalled();
   });

--- a/src/containers/Login/test.js
+++ b/src/containers/Login/test.js
@@ -56,7 +56,7 @@ describe('Login component', () => {
     expect(mockRouter.push).not.toHaveBeenCalled();
 
     return mockDispatch.mock.calls[0][0].then(() => {
-        expect(mockRouter.push).toHaveBeenCalledWith('/');
+      expect(mockRouter.push).toHaveBeenCalledWith('/');
     });
   });
 });

--- a/src/containers/RecoverPassword/index.js
+++ b/src/containers/RecoverPassword/index.js
@@ -40,9 +40,9 @@ export class RecoverPasswordComponent extends Component {
     const { dispatch, params: { code }, router } = this.props;
 
     const newValues = values.delete('confirmation');
-    return dispatch(recoverPasswordFetch(newValues, code, () =>
+    return dispatch(recoverPasswordFetch(newValues, code)).then(() =>
       setTimeout(() => router.push('/login'), REDIRECTION),
-    ));
+    );
   }
 
   render() {

--- a/src/containers/RecoverPassword/test.js
+++ b/src/containers/RecoverPassword/test.js
@@ -60,8 +60,8 @@ describe('RecoverPassword component', () => {
     expect(mockRouter.push).not.toHaveBeenCalled();
 
     return mockDispatch.mock.calls[0][0].then(() => {
-        jest.runAllTimers();
-        expect(mockRouter.push).toHaveBeenCalledWith('/login');
+      jest.runAllTimers();
+      expect(mockRouter.push).toHaveBeenCalledWith('/login');
     });
   });
 });

--- a/src/containers/RecoverPassword/test.js
+++ b/src/containers/RecoverPassword/test.js
@@ -21,7 +21,7 @@ describe('RecoverPassword component', () => {
     />
   );
   const instance = wrapper.instance();
-  Actions.recoverPasswordFetch = jest.fn(() => createResolvedThenable());
+  Actions.recoverPasswordFetch = jest.fn(() => Promise.resolve());
 
   it('validate function success', () => {
     const values = fromJS({
@@ -55,10 +55,13 @@ describe('RecoverPassword component', () => {
     const expected = values.delete('confirmation');
     instance.handleRecoverPassword(values);
 
-    jest.runAllTimers();
-    expect(Actions.recoverPasswordFetch)
-      .toHaveBeenCalledWith(expected, 'this.is.code');
-    expect(mockRouter.push).toHaveBeenCalledWith('/login');
     expect(mockDispatch).toHaveBeenCalled();
+    expect(Actions.recoverPasswordFetch).toHaveBeenCalledWith(expected, 'this.is.code');
+    expect(mockRouter.push).not.toHaveBeenCalled();
+
+    return mockDispatch.mock.calls[0][0].then(() => {
+        jest.runAllTimers();
+        expect(mockRouter.push).toHaveBeenCalledWith('/login');
+    });
   });
 });

--- a/src/containers/RecoverPassword/test.js
+++ b/src/containers/RecoverPassword/test.js
@@ -5,7 +5,7 @@ import { RecoverPasswordComponent, validate } from './';
 import * as Actions from '../../actions/auth';
 
 describe('RecoverPassword component', () => {
-  const mockDispatch = jest.fn();
+  const mockDispatch = jest.fn(f => f);
   const mockRouter = {
     push: jest.fn(),
   };
@@ -21,7 +21,7 @@ describe('RecoverPassword component', () => {
     />
   );
   const instance = wrapper.instance();
-  Actions.recoverPasswordFetch = jest.fn((values, code, cb) => cb());
+  Actions.recoverPasswordFetch = jest.fn(() => createResolvedThenable());
 
   it('validate function success', () => {
     const values = fromJS({
@@ -57,7 +57,7 @@ describe('RecoverPassword component', () => {
 
     jest.runAllTimers();
     expect(Actions.recoverPasswordFetch)
-      .toHaveBeenCalledWith(expected, 'this.is.code', jasmine.any(Function));
+      .toHaveBeenCalledWith(expected, 'this.is.code');
     expect(mockRouter.push).toHaveBeenCalledWith('/login');
     expect(mockDispatch).toHaveBeenCalled();
   });

--- a/src/containers/Signup/index.js
+++ b/src/containers/Signup/index.js
@@ -34,7 +34,7 @@ export class SignupComponent extends Component {
 
   handleSignup(values) {
     const { dispatch, router } = this.props;
-    return dispatch(signupFetch(values, () => router.push('/')));
+    return dispatch(signupFetch(values)).then(() => router.push('/'));
   }
 
   render() {

--- a/src/containers/Signup/test.js
+++ b/src/containers/Signup/test.js
@@ -5,7 +5,7 @@ import { SignupComponent, validate } from './';
 import * as Actions from '../../actions/auth';
 
 describe('Signup component', () => {
-  const mockDispatch = jest.fn();
+  const mockDispatch = jest.fn(f => f);
   const mockRouter = {
     push: jest.fn(),
   };
@@ -19,7 +19,7 @@ describe('Signup component', () => {
     />
   );
   const instance = wrapper.instance();
-  Actions.signupFetch = jest.fn((values, cb) => cb());
+  Actions.signupFetch = jest.fn(() => createResolvedThenable());
 
   it('validate function success', () => {
     const values = fromJS({
@@ -52,7 +52,7 @@ describe('Signup component', () => {
     instance.handleSignup(values);
 
     expect(Actions.signupFetch)
-      .toHaveBeenCalledWith(values, jasmine.any(Function));
+      .toHaveBeenCalledWith(values);
     expect(mockRouter.push).toHaveBeenCalledWith('/');
     expect(mockDispatch).toHaveBeenCalled();
   });

--- a/src/containers/Signup/test.js
+++ b/src/containers/Signup/test.js
@@ -19,7 +19,7 @@ describe('Signup component', () => {
     />
   );
   const instance = wrapper.instance();
-  Actions.signupFetch = jest.fn(() => createResolvedThenable());
+  Actions.signupFetch = jest.fn(() => Promise.resolve());
 
   it('validate function success', () => {
     const values = fromJS({
@@ -51,9 +51,13 @@ describe('Signup component', () => {
     });
     instance.handleSignup(values);
 
-    expect(Actions.signupFetch)
-      .toHaveBeenCalledWith(values);
-    expect(mockRouter.push).toHaveBeenCalledWith('/');
     expect(mockDispatch).toHaveBeenCalled();
+    expect(Actions.signupFetch).toHaveBeenCalledWith(values);
+    expect(mockRouter.push).not.toHaveBeenCalled();
+
+    return mockDispatch.mock.calls[0][0].then(() => {
+      jest.runAllTimers();
+      expect(mockRouter.push).toHaveBeenCalledWith('/');
+    });
   });
 });

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,29 +3,3 @@ import { FormData, File, FileList } from 'file-api';
 global.FormData = FormData;
 global.File = File;
 global.FileList = FileList;
-
-global.createResolvedThenable = () => {
-  let ok = true;
-  let ret;
-
-  return {
-    setFulfilled(value) {
-      ok = true;
-      ret = value;
-    },
-
-    setRejeted(reason) {
-      ok = false;
-      ret = reason;
-    },
-
-    then(cb, eb) {
-      const f = ok ? cb : eb;
-      if (f) f(ret);
-    },
-
-    catch(eb) {
-      this.then(null, eb);
-    },
-  };
-};

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,29 @@ import { FormData, File, FileList } from 'file-api';
 global.FormData = FormData;
 global.File = File;
 global.FileList = FileList;
+
+global.createResolvedThenable = () => {
+  let ok = true;
+  let ret;
+
+  return {
+    setFulfilled(value) {
+      ok = true;
+      ret = value;
+    },
+
+    setRejeted(reason) {
+      ok = false;
+      ret = reason;
+    },
+
+    then(cb, eb) {
+      const f = ok ? cb : eb;
+      if (f) f(ret);
+    },
+
+    catch(eb) {
+      this.then(null, eb);
+    },
+  };
+};


### PR DESCRIPTION
Instead of passing callbacks to "async" actions, we can use returned promises.
This is possible since redux-thunk, as any sane middleware, will pass-through returns...

Using promises from async actions, makes composition of such actions much easier and standardized...

~~To make tests work with promises, I added a simple utility to mock promises with simple sync thenables (ideal for tests), since jest seems to miss such feature.~~ (figured out that it was not necessary, and that a combination of `Promise.resolve` and jest mocks is probably better.)